### PR TITLE
Add ci integration

### DIFF
--- a/ci/configure.sh
+++ b/ci/configure.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fly -t bosh set-pipeline -p "bosh-ali-storage-cli" \
+    -c "$(dirname "${0}")/pipeline.yml"

--- a/ci/docker/boshcpi.ali-storage-cli/Dockerfile
+++ b/ci/docker/boshcpi.ali-storage-cli/Dockerfile
@@ -1,0 +1,14 @@
+FROM bosh/golang-release
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        awscli \
+        build-essential \
+        curl \
+        git \
+        jq \
+        wget \
+        zip \
+    &&  apt-get clean

--- a/ci/docker/boshcpi.ali-storage-cli/build-image.sh
+++ b/ci/docker/boshcpi.ali-storage-cli/build-image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+my_dir="$( cd "$( dirname "$0" )" && pwd )"
+
+DOCKER_IMAGE=${DOCKER_IMAGE:-bosh/ali-storage-cli}
+
+docker login
+
+echo "Building docker image..."
+docker build -t $DOCKER_IMAGE "${my_dir}"
+
+echo "Pushing docker image to '$DOCKER_IMAGE'..."
+docker push $DOCKER_IMAGE

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,153 @@
+---
+jobs:
+- name: unit-tests
+  public: true
+  build_logs_to_retain: 100
+  serial: true
+  plan:
+    - in_parallel:
+        - get: bosh-ali-storage-cli
+          trigger: true
+        - get: ali-storage-cli-docker-image
+          trigger: true
+    - task: run-unit-tests
+      file: bosh-ali-storage-cli/ci/tasks/run-unit-tests.yml
+
+- name: publish-and-tag
+  plan:
+  - in_parallel:
+    - get: bosh-ali-storage-cli
+      trigger: true
+      passed:
+      - unit-tests
+    - get: ali-storage-cli-docker-image
+      trigger: true
+      passed: [unit-tests]
+    - put: version-semver
+      params:
+        bump: patch
+  - in_parallel:
+    - task: build-linux
+      image: ali-storage-cli-docker-image
+      file: bosh-ali-storage-cli/ci/tasks/build.yml
+      output_mapping: { out: out-linux }
+      params:
+        GOOS: linux
+    - task: build-windows
+      image: ali-storage-cli-docker-image
+      file: bosh-ali-storage-cli/ci/tasks/build.yml
+      output_mapping: { out: out-windows }
+      params:
+        GOOS: windows
+  - in_parallel:
+    - put: release-bucket-linux
+      params: { file: out-linux/ali-storage-cli-*-linux-amd64 }
+    - put: release-bucket-windows
+      params: { file: out-windows/ali-storage-cli-*-windows-amd64.exe }
+  - put: bosh-ali-storage-cli
+    params:
+      repository: bosh-ali-storage-cli
+      rebase: true
+      tag: version-semver/number
+      tag_prefix: v
+
+- name: build-ali-storage-cli-docker-image
+  plan:
+  - get: bosh-ali-storage-cli
+    resource: bosh-ali-storage-cli-for-docker-image-creation
+    trigger: true
+  - get: bosh-golang-release-image
+    trigger: true
+  - put: ali-storage-cli-docker-image
+    params:
+      build: "bosh-ali-storage-cli/ci/docker/boshcpi.ali-storage-cli"
+    get_params:
+      skip_download: true
+
+- name: bump-deps
+  plan:
+    - in_parallel:
+        - get: bosh-ali-storage-cli
+        - get: golang-release
+        - get: weekly
+          trigger: true
+    - task: bump-deps
+      file: golang-release/ci/tasks/shared/bump-deps.yml
+      input_mapping:
+        input_repo: bosh-ali-storage-cli
+      output_mapping:
+        output_repo: bumped-bosh-ali-storage-cli
+    - task: unit-tests
+      file: bosh-ali-storage-cli/ci/tasks/run-unit-tests.yml
+      input_mapping:
+        bosh-ali-storage-cli: bumped-bosh-ali-storage-cli
+    - put: bosh-ali-storage-cli
+      params:
+        repository: bumped-bosh-ali-storage-cli
+        rebase: true
+resources:
+- name: bosh-ali-storage-cli
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/bosh-ali-storage-cli.git
+    branch: main
+    private_key: ((github_deploy_key_bosh-ali-storage-cli.private_key))
+
+- name: bosh-ali-storage-cli-for-docker-image-creation
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/bosh-ali-storage-cli.git
+    branch: main
+    private_key: ((github_deploy_key_bosh-ali-storage-cli.private_key))
+    paths: ["ci/docker/*"]
+
+- name: golang-release
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/bosh-package-golang-release.git
+
+- name: version-semver
+  type: semver
+  source:
+    initial_version: 0.0.1
+    key: current-version
+    bucket: bosh-ali-storage-cli-artifacts
+    access_key_id: ((bosh_ali_storage_cli_pipeline.username))
+    secret_access_key: ((bosh_ali_storage_cli_pipeline.password))
+
+- name: release-bucket-linux
+  type: s3
+  source:
+    regexp: ali-storage-cli-(.*)-linux-amd64
+    bucket: bosh-ali-storage-cli-artifacts
+    access_key_id: ((bosh_ali_storage_cli_pipeline.username))
+    secret_access_key: ((bosh_ali_storage_cli_pipeline.password))
+
+- name: release-bucket-windows
+  type: s3
+  source:
+    regexp: ali-storage-cli-(.*)-windows-amd64\.exe
+    bucket: bosh-ali-storage-cli-artifacts
+    access_key_id: ((bosh_ali_storage_cli_pipeline.username))
+    secret_access_key: ((bosh_ali_storage_cli_pipeline.password))
+
+- name: bosh-golang-release-image
+  type: docker-image
+  source:
+    repository: bosh/golang-release
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+
+- name: ali-storage-cli-docker-image
+  type: docker-image
+  source:
+    repository: bosh/ali-storage-cli
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
+
+- name: weekly
+  type: time
+  source:
+    start: 12:00
+    stop: 13:00
+    days: [ Saturday ]

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+my_dir="$( cd "$(dirname "${0}")" && pwd )"
+release_dir="$( cd "${my_dir}" && cd ../.. && pwd )"
+workspace_dir="$( cd "${release_dir}" && cd .. && pwd )"
+
+go_bin=$(go env GOPATH)
+export PATH=${go_bin}/bin:${PATH}
+export CGO_ENABLED=0
+
+# inputs
+semver_dir="${workspace_dir}/version-semver"
+
+# outputs
+output_dir=${workspace_dir}/out
+
+semver="$(cat "${semver_dir}/number")"
+
+binname="ali-storage-cli-${semver}-${GOOS}-amd64"
+if [ "${GOOS}" = "windows" ]; then
+	binname="${binname}.exe"
+fi
+
+pushd "${release_dir}" > /dev/null
+  echo -e "\n building artifact with $(go version)..."
+  go build -ldflags "-X main.version=${semver}" \
+    -o "out/${binname}"                          \
+    github.com/cloudfoundry/bosh-ali-storage-cli
+
+  echo -e "\n sha1 of artifact..."
+  sha1sum "out/${binname}"
+
+  mv "out/${binname}" "${output_dir}/"
+popd > /dev/null

--- a/ci/scripts/run-unit-tests.sh
+++ b/ci/scripts/run-unit-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CGO_ENABLED=0
+
+# log current go version
+go version
+
+# run unit tests
+go run github.com/onsi/ginkgo/v2/ginkgo --skip-file=integration ./...

--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: bosh/ali-storage-cli
+inputs:
+- name: bosh-ali-storage-cli
+- name: version-semver
+outputs:
+- name: out
+run:
+  path: bosh-ali-storage-cli/ci/scripts/build.sh
+params:
+  GOOS: linux

--- a/ci/tasks/run-unit-tests.yml
+++ b/ci/tasks/run-unit-tests.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: bosh/ali-storage-cli
+
+inputs:
+  - name: bosh-ali-storage-cli
+
+run:
+  path: ci/scripts/run-unit-tests.sh
+  dir: bosh-ali-storage-cli

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,11 @@
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/onsi/ginkgo/v2"
+)
+
+// This file imports packages that are used when running go generate, or used
+// during the development process but not otherwise depended on by built code.


### PR DESCRIPTION
This copies the existing ci integration from [bosh-azure-storage-cli](https://github.com/cloudfoundry/bosh-azure-storage-cli) and just replaces all occurrences of "azure" by "ali".

It is expected to fail on merge since it depends on some yet not existing credhub keys that need to bee added by a privileged developer.

Here the list of missing keys:
- ((github_deploy_key_bosh-ali-storage-cli.private_key))
- ((bosh_ali_storage_cli_pipeline.username))
- ((bosh_ali_storage_cli_pipeline.password))
- ((dockerhub_username))
- ((dockerhub_password))

Additionally this PR depends on: https://github.com/cloudfoundry/bosh-ali-storage-cli/pull/3